### PR TITLE
feat: read the season from the environment at runtime

### DIFF
--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,5 +1,10 @@
-# Copy to .env and fill in. All values are required at build time, since they
-# are imported via $env/static/private.
+# Copy to .env and fill in.
+#
+# MONGO_URL, MAIN_DB and PREDICTIONS_DB are imported via $env/static/private and
+# so are baked in at build time: changing one needs a rebuild.
+#
+# SEASON is read at runtime via $env/dynamic/private, so it can be changed
+# without rebuilding.
 
 # Full MongoDB connection string
 MONGO_URL=mongodb+srv://user:password@host/database
@@ -9,3 +14,8 @@ MAIN_DB=PremierLeague
 
 # Database holding the v2 (OddsV2) predictions collection
 PREDICTIONS_DB=Predictions
+
+# Current Premier League season (the year the season started in). Must match
+# the updater's own SEASON, since the updater writes the TeamData document
+# keyed by this year and the dashboard reads it back.
+SEASON=2025

--- a/dashboard/src/lib/consts.ts
+++ b/dashboard/src/lib/consts.ts
@@ -1,1 +1,0 @@
-export const CURRENT_SEASON = 2025

--- a/dashboard/src/lib/server/database/queries.ts
+++ b/dashboard/src/lib/server/database/queries.ts
@@ -1,8 +1,38 @@
 import { error } from '@sveltejs/kit';
-import { CURRENT_SEASON } from '$lib/consts';
+import { env } from '$env/dynamic/private';
 import { teams } from '$lib/server/database/teams';
 import { fantasy } from '$lib/server/database/fantasy';
 import type { TeamsData } from '../../../routes/[team]/dashboard.types';
+
+/**
+ * The season the dashboard reads, from the SEASON environment variable.
+ *
+ * Read at runtime via $env/dynamic/private rather than $env/static/private:
+ * static values are inlined at build time, so rolling the season over would
+ * still mean a rebuild and redeploy. This way it is a restart, or nothing at
+ * all where the host injects the variable per request.
+ *
+ * Named SEASON to match the updater's own environment variable, since the two
+ * have to agree: the updater writes the TeamData document this reads.
+ */
+function currentSeason(): number {
+	const raw = env.SEASON;
+	if (!raw) {
+		throw error(
+			500,
+			'SEASON is not set, so the dashboard cannot tell which season to read.'
+		);
+	}
+
+	// The updater keys TeamData documents by an integer _id. Passing the raw
+	// string would match no document and surface as a "no team data" 500, which
+	// looks like missing data rather than a misconfigured variable.
+	const season = Number(raw);
+	if (!Number.isInteger(season)) {
+		throw error(500, `SEASON must be an integer, got "${raw}".`);
+	}
+	return season;
+}
 
 /**
  * Fetch the team data document for the current season.
@@ -11,9 +41,10 @@ import type { TeamsData } from '../../../routes/[team]/dashboard.types';
  * updater has not populated the database, which callers cannot recover from.
  */
 export async function fetchTeams(): Promise<TeamsData> {
-	const data = await teams.findOne({ _id: CURRENT_SEASON as unknown as never });
+	const season = currentSeason();
+	const data = await teams.findOne({ _id: season as unknown as never });
 	if (!data) {
-		throw error(500, `No team data found for season ${CURRENT_SEASON}`);
+		throw error(500, `No team data found for season ${season}`);
 	}
 	return data as unknown as TeamsData;
 }


### PR DESCRIPTION
CURRENT_SEASON was a constant in src/lib/consts.ts, so rolling the season over each August meant editing code and republishing the dashboard.

It now comes from a SEASON environment variable, read via $env/dynamic/private. The dynamic flavour matters: $env/static/private, which the existing MONGO_URL/MAIN_DB/PREDICTIONS_DB use, is inlined at build time and would still have required a rebuild, leaving the actual problem in place. Confirmed against the build output, where SEASON compiles to a private_env.SEASON lookup and the literal 2025 appears nowhere in the server bundle.

The value is parsed to a number before querying. The updater keys TeamData documents by an integer _id, so passing the raw string would match no document and surface as a "no team data found" 500 that reads like missing data rather than a misconfigured variable. Unset and non-integer values each fail with their own message.

Named SEASON to match the variable the updater already uses, since the two must agree: the updater writes the document the dashboard reads.

Safe from prerendering: the only prerendered route is home/+page.ts, which does not call fetchTeams.

Verified with svelte-check (276 files, 0 errors) and npm run build.