### PR TITLE
fix(dashboard): stop the next-game score prediction linking to /predictions

### DIFF
--- a/dashboard/src/routes/[team]/NextGame.svelte
+++ b/dashboard/src/routes/[team]/NextGame.svelte
@@ -56,12 +56,7 @@
 					<div class="next-game-item">
 						Score prediction
 						<br />
-						<a
-							class="text-[var(--purple)] no-underline hover:text-[rgb(120_120_120)]"
-							href="/predictions"
-						>
-							<b>{predictedScoreline(data, team)}</b>
-						</a>
+						<b class="text-[var(--purple)]">{predictedScoreline(data, team)}</b>
 						<br />
 					</div>
 				</div>


### PR DESCRIPTION
The predicted scoreline in the Next Game panel was wrapped in an anchor to /predictions. It is now plain text.

The anchor only existed to carry the link, so its link-specific styling goes with it: no-underline had nothing to underline, and the grey hover colour no longer signals anything. The purple stays, so the scoreline looks exactly as it did, and the absorbs the class rather than keeping a wrapper element that no longer does anything.

Nothing else depended on it: no CSS in the component targets the anchor, and hover:text-[rgb(120_120_120)] had no other user, so no rule for it is emitted any more. The /predictions link on the predictions page's own nav is untouched.

svelte-check passes and the production build succeeds.