### PR TITLE
fix(dashboard): correct the Vs big 6 spider attribute

### DIFF
--- a/dashboard/src/routes/[team]/spider-graph/vsBig6.ts
+++ b/dashboard/src/routes/[team]/spider-graph/vsBig6.ts
@@ -1,6 +1,6 @@
 import type { Form, SpiderAttribute, TeamAttributes, TeamsData } from '../dashboard.types';
 import { getTeams } from '$lib/team';
-import { attributeAvgScaled, removeItem, seasonComplete } from './util';
+import { attributeAvgScaled, seasonComplete } from './util';
 import { Team } from '$lib/types';
 
 // Enum members rather than bare strings: Team is an enum, so the strings were
@@ -20,7 +20,10 @@ function formWinsVsBig6(form: Form, team: Team, season: number, big6: Team[]) {
 	let numPlayed = 0;
 	for (const matchday in form[team][season]) {
 		const match = form[team][season][matchday];
-		if (match.score == null || (match.team !== null && big6.includes(match.team))) {
+		// Only played matches, and only against a big 6 opponent. This read
+		// `big6.includes(match.team)` without the negation, which skipped the
+		// big 6 matches and scored the team against everyone else instead.
+		if (match.score == null || match.team === null || !big6.includes(match.team)) {
 			continue;
 		}
 		if (
@@ -50,6 +53,12 @@ export default function getVsBig6(data: TeamsData, numSeasons: number) {
 	let maxAvgSeasonPointsVsBig6 = Number.NEGATIVE_INFINITY;
 	const teams = getTeams(data);
 	for (const team of teams) {
+		// filter, not removeItem: removeItem splices in place, and big6 is a
+		// module-level array, so every big 6 team removed itself from it
+		// permanently. One pass over the teams emptied it, and later teams (and
+		// every later render) were measured against nothing at all.
+		const big6Opponents = big6.filter((opponent) => opponent !== team);
+
 		let totalPointsVsBig6 = 0;
 		let totalPlayedVsBig6 = 0;
 		for (let i = 0; i < numSeasons; i++) {
@@ -57,12 +66,12 @@ export default function getVsBig6(data: TeamsData, numSeasons: number) {
 				data.form,
 				team,
 				data._id - i,
-				removeItem(big6, team)
+				big6Opponents
 			);
 			if (seasonPlayedVsBig6 === 0) {
 				continue;
 			}
-			const avgSeasonPointsVsBig6 = seasonPlayedVsBig6 / seasonPlayedVsBig6;
+			const avgSeasonPointsVsBig6 = seasonPointsVsBig6 / seasonPlayedVsBig6;
 			// If season completed, check if season consistency is highest yet
 			if (
 				seasonComplete(data, team, data._id - i) &&
@@ -81,7 +90,11 @@ export default function getVsBig6(data: TeamsData, numSeasons: number) {
 
 	const attribute: SpiderAttribute = {
 		teams: finalisedVsBig6,
-		avg: attributeAvgScaled(finalisedVsBig6, maxAvgSeasonPointsVsBig6 * numSeasons)
+		// No `* numSeasons` here, unlike cleanSheets/consistency/winStreak. Those
+		// store a total across seasons, so their ceiling is the best season times
+		// the number of seasons. This stores points *per game*, so its ceiling is
+		// simply the best points per game any team managed in a season.
+		avg: attributeAvgScaled(finalisedVsBig6, maxAvgSeasonPointsVsBig6)
 	};
 	return attribute;
 }


### PR DESCRIPTION
The axis measured the opposite of its label, against a list that emptied itself, on a scale derived from a constant. Four faults, all in spider-graph/vsBig6.ts.

The filter was inverted. The skip condition read

    if (match.score == null || (match.team !== null && big6.includes(match.team)))

so every match against a big 6 side was skipped and the team was scored against everyone else instead. The axis is labelled "Vs big 6".

The big 6 list emptied itself. Each team was compared against removeItem(big6, team), and removeItem splices in place. big6 is a module-level array, so every big 6 team permanently removed itself from it: one pass over the teams left it empty, and every later render measured against nothing. Replaced with a non-mutating filter. removeItem itself is kept, since SpiderGraph.svelte uses it where the mutation is intended.

The per-season average was a tautology:

    const avgSeasonPointsVsBig6 = seasonPlayedVsBig6 / seasonPlayedVsBig6;

always 1, so maxAvgSeasonPointsVsBig6 was 1 whenever any team completed a season with a big 6 fixture. Now points over played, as the name says.

The scale then double-counted the seasons. cleanSheets, consistency and winStreak each store a total across seasons and scale by maxSeason * numSeasons, which is their ceiling. This attribute stores points *per game*, so its ceiling is the best per-game average alone. The
* numSeasons is dropped.

Measured against a real payload, replaying both versions over the same form data with the seasonComplete guard applied:

    old   max 1.000  scale 4.000  big6 list ends with 0 entries
          Arsenal 56.8, Man City 54.4, Liverpool 51.8
    new   max 2.200  scale 2.200  big6 list intact
          Arsenal 86.4, Man City 66.7, Liverpool 63.6

The ordering is broadly preserved but the values now mean what the axis says, and the best side approaches the top of the scale instead of sitting near half of it.

svelte-check 0 errors, eslint and prettier clean, build succeeds.